### PR TITLE
Added bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,15 @@
+{
+  "name": "mixen",
+  "main": "mixen.coffee",
+  "version": "0.5.4",
+  "homepage": "http://github.hubspot.com/mixen/",
+  "authors": [
+    "Zack Bloom <zbloom@hubspot.com>"
+  ],
+  "description": "Combine Javascript classes on the fly",
+  "license": "MIT",
+  "ignore": [
+    "node_modules",
+    "bower_components"
+  ]
+}


### PR DESCRIPTION
Allows people to properly use Mixen with [Bower](http://bower.io/). It can be used as is, but having a bowerfile here means users don't have to create their own to specify the `main` attribute.
